### PR TITLE
Update to fix HTTP endpoints

### DIFF
--- a/webapp/src/test/resources/oidc.properties
+++ b/webapp/src/test/resources/oidc.properties
@@ -1,3 +1,3 @@
-oidc.callback.url=http://localhost:9080/callback
+oidc.callback.url=https://localhost:9080/callback
 oidc.client.id=54879548932
 oidc.client.secret=dhsudhbhfjksiofkjhsdazjky438iory43huicwga56jkxmfllsaATYfgszhduidks


### PR DESCRIPTION
Some of the endpoints are still using HTTP that is insecure ... replaced with secure HTTP (HTTP with SSL/TLS) that exists

Details:

I found instances where the HTTP protocol is used instead of HTTPS (HTTP with TLS). According to the Common Weakness Enumeration organization this is a security weakness (https://cwe.mitre.org/data/definitions/319.html).

I also found hard-coded secrets