### PR TITLE
Add default case for switch statements

### DIFF
--- a/webapp/src/test/java/it/mulders/futbolin/webapp/security/MockClaims.java
+++ b/webapp/src/test/java/it/mulders/futbolin/webapp/security/MockClaims.java
@@ -32,6 +32,10 @@ public class MockClaims implements Claims {
             case "email": return (T) email;
             case "name": return (T) name;
             case "sub": return (T) subject;
+            //missing default case
+            default:
+                 // add default case
+                break;
         }
 
         throw new UnsupportedOperationException();


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html